### PR TITLE
feat: add search/filter query param to items endpoint

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -189,6 +189,17 @@
         "tags": [
           "Items"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "Conference"
+            },
+            "required": false,
+            "name": "search",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "List persisted items",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -37,6 +37,16 @@ const UpdateItemSchema = z.object({
   type: z.string().trim().max(60).nullable().optional().openapi({ example: 'Room' })
 }).openapi('UpdateItem')
 
+const ItemsQuerySchema = z.object({
+  search: z.string().optional().openapi({
+    param: {
+      name: 'search',
+      in: 'query'
+    },
+    example: 'Conference'
+  })
+}).openapi('ItemsQuery')
+
 const ItemParamsSchema = z.object({
   id: z.coerce.number().int().positive().openapi({
     param: {
@@ -83,6 +93,9 @@ const listItemsRoute = createRoute({
   method: 'get',
   path: '/items',
   tags: ['Items'],
+  request: {
+    query: ItemsQuerySchema
+  },
   responses: {
     200: {
       description: 'List persisted items',
@@ -211,7 +224,9 @@ app.openapi(healthRoute, (c) => {
 })
 
 app.openapi(listItemsRoute, async (c) => {
+  const { search } = c.req.valid('query')
   const items = await prisma.item.findMany({
+    where: search ? { title: { contains: search } } : undefined,
     orderBy: {
       createdAt: 'desc'
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,12 +23,14 @@ export default function App() {
   const [description, setDescription] = useState("");
   const [type, setType] = useState("");
   const [editing, setEditing] = useState<EditingState | null>(null);
+  const [search, setSearch] = useState("");
 
   const queryClient = useQueryClient();
   const refreshItems = () =>
     queryClient.invalidateQueries({ queryKey: getGetItemsQueryKey() });
 
-  const itemsQuery = useGetItems();
+  const searchParam = search.trim() || undefined;
+  const itemsQuery = useGetItems(searchParam ? { search: searchParam } : undefined);
   const createItemMutation = usePostItems({
     mutation: {
       onSuccess: async () => {
@@ -180,7 +182,15 @@ export default function App() {
         ) : null}
 
         <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="text-sm font-medium text-slate-700">Resources</h2>
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-medium text-slate-700">Resources</h2>
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name..."
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm outline-none focus:border-slate-500 w-48"
+            />
+          </div>
 
           {itemsQuery.isPending ? (
             <p className="mt-3 text-sm text-slate-600">Loading resources...</p>

--- a/web/src/api/generated/hooks.ts
+++ b/web/src/api/generated/hooks.ts
@@ -97,6 +97,10 @@ export interface UpdateItem {
   type?: string | null;
 }
 
+export type GetItemsParams = {
+search?: string;
+};
+
 export const get = (
 
  signal?: AbortSignal
@@ -272,13 +276,14 @@ export function useGetHealth<TData = Awaited<ReturnType<typeof getHealth>>, TErr
 
 
 export const getItems = (
-
+    params?: GetItemsParams,
  signal?: AbortSignal
 ) => {
 
 
       return customClient<ItemListResponse>(
-      {url: `/items`, method: 'GET', signal
+      {url: `/items`, method: 'GET',
+        params, signal
     },
       );
     }
@@ -286,23 +291,23 @@ export const getItems = (
 
 
 
-export const getGetItemsQueryKey = () => {
+export const getGetItemsQueryKey = (params?: GetItemsParams,) => {
     return [
-    `/items`
+    `/items`, ...(params ? [params] : [])
     ] as const;
     }
 
 
-export const getGetItemsQueryOptions = <TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+export const getGetItemsQueryOptions = <TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetItemsQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getGetItemsQueryKey(params);
 
 
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getItems>>> = ({ signal }) => getItems(signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getItems>>> = ({ signal }) => getItems(params, signal);
 
 
 
@@ -316,7 +321,7 @@ export type GetItemsQueryError = ErrorType<unknown>
 
 
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
+ params: undefined |  GetItemsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof getItems>>,
           TError,
@@ -326,7 +331,7 @@ export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
+ params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof getItems>>,
           TError,
@@ -336,16 +341,16 @@ export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+ params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+ params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
  , queryClient?: QueryClient
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getGetItemsQueryOptions(options)
+  const queryOptions = getGetItemsQueryOptions(params,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 


### PR DESCRIPTION
## Summary

Implements #6 — adds a \`search\` query parameter to the \`GET /items\` endpoint so the API handles filtering server-side, and adds a search input in the frontend.

## Changes

- **API** (\`api/src/app.ts\`): Added optional \`search\` query param to \`GET /items\`; filters items by \`title\` via Prisma \`contains\` when provided
- **OpenAPI** (\`api/openapi.json\`): Regenerated to reflect the new query parameter
- **Generated client** (\`web/src/api/generated/hooks.ts\`): Regenerated via Orval — \`GetItemsParams.search?: string\`
- **Frontend** (\`web/src/App.tsx\`): Added search input; passes \`search\` param to \`useGetItems\` so filtering is done by the API, not locally

## Closes

Closes #6