### PR TITLE
feat: add reservation status filter

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ function ItemReservations({ item }: { item: Item }) {
   const [endAt, setEndAt] = useState("");
   const [purpose, setPurpose] = useState("");
   const [notes, setNotes] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
 
   const refreshReservations = () =>
     queryClient.invalidateQueries({ queryKey: getGetItemsIdReservationsQueryKey(item.id) });
@@ -77,6 +78,10 @@ function ItemReservations({ item }: { item: Item }) {
   };
 
   const reservations = reservationsQuery.data?.reservations ?? [];
+  const filteredReservations =
+    statusFilter === "all"
+      ? reservations
+      : reservations.filter((r) => r.status === statusFilter);
 
   return (
     <div className="mt-2 border-t pt-3 space-y-3" style={{ borderColor: "#f5f2ed" }}>
@@ -141,14 +146,41 @@ function ItemReservations({ item }: { item: Item }) {
         </button>
       </form>
 
+      {/* Status filter */}
+      {!reservationsQuery.isPending && reservations.length > 0 && (
+        <div className="flex gap-1 flex-wrap">
+          {(["all", "pending", "confirmed", "cancelled"] as const).map((key) => {
+            const label = key === "all" ? "Alle" : (STATUS_LABELS[key] ?? key);
+            const isActive = statusFilter === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setStatusFilter(key)}
+                className="rounded-none border px-2 py-0.5 text-xs font-medium uppercase tracking-wider"
+                style={
+                  isActive
+                    ? { backgroundColor: "#4a5c38", color: "#f5f2ed", borderColor: "#4a5c38" }
+                    : { backgroundColor: "transparent", color: "#4a5c38", borderColor: "#c8b99a" }
+                }
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       {/* Existing reservations */}
       {reservationsQuery.isPending ? (
         <p className="text-xs" style={{ color: "#4a5c38" }}>Laster reservasjoner...</p>
       ) : reservations.length === 0 ? (
         <p className="text-xs font-light" style={{ color: "#4a5c38" }}>Ingen reservasjoner ennå.</p>
+      ) : filteredReservations.length === 0 ? (
+        <p className="text-xs font-light" style={{ color: "#4a5c38" }}>Ingen reservasjoner matcher filteret.</p>
       ) : (
         <ul className="space-y-2">
-          {reservations.map((r) => {
+          {filteredReservations.map((r) => {
             const colors = STATUS_COLORS[r.status] ?? STATUS_COLORS.pending;
             return (
               <li key={r.id} className="flex items-start justify-between gap-2 rounded-none p-2" style={{ backgroundColor: "#f5f2ed" }}>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,13 +29,16 @@ const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
   cancelled: { bg: "#f9fafb", text: "#6b7280" },
 };
 
+type StatusFilter = "all" | "pending" | "confirmed" | "cancelled";
+const STATUS_FILTER_KEYS: StatusFilter[] = ["all", "pending", "confirmed", "cancelled"];
+
 function ItemReservations({ item }: { item: Item }) {
   const queryClient = useQueryClient();
   const [startAt, setStartAt] = useState("");
   const [endAt, setEndAt] = useState("");
   const [purpose, setPurpose] = useState("");
   const [notes, setNotes] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 
   const refreshReservations = () =>
     queryClient.invalidateQueries({ queryKey: getGetItemsIdReservationsQueryKey(item.id) });
@@ -149,7 +152,7 @@ function ItemReservations({ item }: { item: Item }) {
       {/* Status filter */}
       {!reservationsQuery.isPending && reservations.length > 0 && (
         <div className="flex gap-1 flex-wrap">
-          {(["all", "pending", "confirmed", "cancelled"] as const).map((key) => {
+          {STATUS_FILTER_KEYS.map((key) => {
             const label = key === "all" ? "Alle" : (STATUS_LABELS[key] ?? key);
             const isActive = statusFilter === key;
             return (
@@ -157,6 +160,7 @@ function ItemReservations({ item }: { item: Item }) {
                 key={key}
                 type="button"
                 onClick={() => setStatusFilter(key)}
+                aria-pressed={isActive}
                 className="rounded-none border px-2 py-0.5 text-xs font-medium uppercase tracking-wider"
                 style={
                   isActive


### PR DESCRIPTION
## What
Adds a client-side status filter to the reservations list inside each resource card.

## How
- Added `statusFilter` state (`'all' | 'pending' | 'confirmed' | 'cancelled'`) to `ItemReservations`
- Derived `filteredReservations` from the fetched list based on active filter
- Rendered filter toggle buttons (Alle / Venter / Bekreftet / Kansellert) above the list when reservations exist
- Active filter is visually highlighted (green fill); inactive buttons use border-only style
- Added a "Ingen reservasjoner matcher filteret." empty state when filter yields no results

## Changes
- `web/src/App.tsx` — filter state, derived list, filter UI, updated rendering

## Checklist
- [x] TypeScript typecheck passes
- [x] Build passes
- [x] No generated files hand-edited
- [x] Diff is small and reviewable

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added status-based filtering for reservations list, allowing users to view reservations by their status.
  * Improved empty-state messaging to distinguish between no reservations and no reservations matching the selected filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->